### PR TITLE
List all posts

### DIFF
--- a/classes/Post.php
+++ b/classes/Post.php
@@ -16,20 +16,50 @@ class Post
 	private $image;
 	private $date;
 	private $category;
+	private $id;
 
   // Method to create a new post. 
 	public function __construct($title, $description, $created_by, $category) 
 	{
 		$this->title = $title;
 		$this->description = $description;
-		$this->date = date("Y-m-d"); // Prints sql friendly date 2018-11-22
+		$this->date = date("Y-m-d"); // Prints the date to today's date like 2018-11-22
 		$this->created_by = $created_by;
 		$this->category = $category; 
+	}
+
+	/*
+	* This function will be used by Posts_access.php to build a post from the database. 
+	* It returns each row of the query result set as a Post object.
+	* The parameters should always match the order of the columns in the datase.
+	*/ 
+
+	public static function build_post_from_pdo($id, $title, $description, $created_by, $image, $date, $category) {
+		// use the constructor to create the post instance
+		$post_from_database = new self($title, $description, $created_by, $category);
+		// since my constructor doesn't have id, image or date, we need to 
+		$post_from_database->set_id($id);
+		$post_from_database->set_image($image);
+		$post_from_database->set_date($date); // This will overwrite the date from the constructor and instead use the date from the database 
+		return $post_from_database;
 	}
 
 	// Setter methods below
 	public function set_image($image) {
 		$this->image = $image;
+	}
+
+	/*
+	* These setters below are private because nothing outside of this class is going to use them
+	* Only to be used in the build_post_from_pdo function
+	*/
+
+	private function set_id($id) {
+		$this->id = $id;
+	}
+
+	private function set_date($date) {
+		$this->date = $date;
 	}
 
 	// Below are all the getters methods for the class properties

--- a/classes/Posts_access.php
+++ b/classes/Posts_access.php
@@ -26,13 +26,15 @@ class Access_posts
   	]);
   }
 
-  public function list_posts()
+  public function list_all_posts()
   {
     $statement = $this->pdo->prepare("SELECT * from posts ORDER BY date DESC");
-    // execute and return as list of Post objects
+    $statement->execute();
+    // return an array consisting of objects from the Post class using build_post_from_pdo function on each of the rows in the query result set
+    return $statement->fetchAll(PDO::FETCH_FUNC, "Post::build_post_from_pdo");
   }
 
-  public function list_posts_for_user($user_id)
+  public function list_single_post($post_id)
   {
     $statement = $this->pdo->prepare("SELECT * from posts WHERE user_id = :user_id ORDER BY date DESC");
     // execute and return as list of Post objects

--- a/views/home_page.php
+++ b/views/home_page.php
@@ -1,6 +1,8 @@
 <?php
     session_start();
-    include "../includes/head.php";  
+    include "../includes/head.php";
+    require_once "../includes/database_connection.php";
+    require_once "../classes/Posts_access.php";
 ?>
 
 
@@ -19,12 +21,11 @@
 				<h1>Latest Posts</h1>
 				<hr>
 			</div>
-
 			<div class="row latest_post_wrapper justify-content-between">
 				<div class="col-12 col-md-4">
 					<div>
 						<!--here we should fetch latest post title-->
-						<h2></h2>
+						<h2></h2> 
 					</div>
 
 					<div>
@@ -63,14 +64,18 @@
 		<section class="row all_posts">
 			
 			<!-- Here we will include post array, and return image and title -->
+			<?php $access_posts = new Access_posts($pdo);
+			$posts = $access_posts->list_all_posts();
+			?>
+			<?php foreach ($posts as $post) {?>
 			<div class="col-12 col-5 single_post">
-				<div><!-- Post Image--></div>
-				<div><!-- Post Title--></div>
+				<div><img src="<?= $post->get_image();?>"></div>
+				<div><?= $post->get_title();?></div>
 				<div>
 					<button type="button" class="btn btn-outline-primary">Read More</button>
 				</div>
-			<!-- Col -->	
-			</div>
+				<!-- Col -->	
+			</div><?php }?>
 		</section>			
 
 	</main>


### PR DESCRIPTION
For maintainability reasons, we don’t want an associative array to list the posts. We want of a list of Post objects.

Everything that deals with a single post has to deal with the Post class and be an object of the Post class. Which is why we want to return a list of Post objects and not an associative array. We will have to change our execute statement in order to do that

Instead of writing FETCH_ASSOC, we will instead do PDO::FETCH_FUNC. It returns the results of calling the specified function, using each row's columns as parameters in the call.

Read more here under example no 5: 
http://php.net/manual/en/pdostatement.fetchall.php