### PR TITLE
Check if the user is an admin

### DIFF
--- a/includes/login_controller.php
+++ b/includes/login_controller.php
@@ -20,6 +20,7 @@ if($is_password_correct){
   //Save user globally to session
   $_SESSION["username"] = $fetched_user["username"];
   $_SESSION["id"] = $fetched_user["id"];
+  $_SESSION["admin"] = $fetched_user["admin"];
   header('Location: ../views/home_page.php');
 
 }else{

--- a/includes/nav-bar.php
+++ b/includes/nav-bar.php
@@ -18,12 +18,21 @@
                     <li class="nav-item">
                         <a class="nav-link" href="../views/home_page.php">Blog</a>
                     </li>
+                    <?php if (isset($_SESSION["username"])) {?>
+                    <li class="nav-item">
+                        <a class="nav-link" href="../includes/logout.php">Log out</a>
+                    </li>
+                    <?php } else {?>
                     <li class="nav-item">
                         <a class="nav-link" href="../views/login_page.php">Sign in</a>
                     </li>
+                    <?php }?>
+                    <!-- Check if the user is an admin-->
+                    <?php if ($_SESSION["admin"] == 1){?> 
                     <li class="nav-item">
                         <a class="nav-link" href="../views/create_post_page.php">Create Post</a>
                     </li>
+                    <?php }?>
                     <li class="nav-item">
                         <a class="nav-link" href="../views/about_page.php">About</a>
                     </li>

--- a/views/single_post_page.php
+++ b/views/single_post_page.php
@@ -55,7 +55,14 @@
 		
 		<section class="comments">
 			<!--include comment field-->
-			<!--if admin include editing buttons-->
+
+			<!-- add admin cta area-->
+			<?php if ($_SESSION["admin"] == 1) {?>
+				<div class="admin-cta-area">
+					<a href="../includes/edit_post.php" class="btn btn-outline-primary">Edit post</a>
+					<a href="../includes/delete_post.php" class="btn btn-outline-primary">Delete post</a>
+				</div>
+			<?php }?>
 			<!--list comments-->
 		</section>
 


### PR DESCRIPTION
Saved $_SESSION["admin"] to $fetched_user["admin"] 
Made the Create post link in the navbar visible only to admins
Added two new buttons under single_post_page, Edit post and Delete post, that will only show if you're an admin
Added a Log out link in the navbar that will show if you're logged in (while hiding the Sign in)