### PR TITLE
Use getter methods edit post

### DIFF
--- a/classes/PostMethods.php
+++ b/classes/PostMethods.php
@@ -83,16 +83,16 @@ class PostMethods
     ]);
   }
 
-  public function edit_post()
+  public function edit_post(Post $edited_post)
   {
     try{
       $statement = $this->pdo->prepare("UPDATE posts SET title = :title, description = :description, image = :image, category = :category WHERE posts.id = :id;");
       $statement->execute ([
-        ":title" => $_POST["title"],
-        ":description" => $_POST["description"],
-        ":image" => $_POST["image"],
-        ":category" => $_POST["category"],
-        ":id" => $_GET["id"]
+        ":title" => $edited_post->get_title(),
+        ":description" => $edited_post->get_description(),
+        ":image" => $edited_post->get_image(),
+        ":category" => $edited_post->get_category(),
+        ":id" => $edited_post->get_id()
       ]);
     }catch (PDOException $exception) {
       echo "Connection error" . $exception->getMessage();

--- a/includes/actions_posts.php
+++ b/includes/actions_posts.php
@@ -15,30 +15,9 @@ switch ($_GET["action"]) {
     $created_by = $_SESSION["username"];
     $image_url = $_POST["image"];
 
-    $do_redirect = true;
-
     $post_methods = new PostMethods($pdo);
 
-      // Title validation: Cannot be empty
-    if (empty($title)) {
-      $empty_title = true;
-      $empty_title_error_message = 'Please enter a title';
-      $do_redirect = false;
-    } 
-
-      // Description validation: Cannot be empty
-    if (empty($description)) {
-      $empty_description = true;
-      $empty_description_error_message = 'You cannot submit an empty blog post';
-      $do_redirect = false;
-    } 
-
-      // Category validation: Cannot be empty
-    if (empty($category)) {
-      $empty_category = true;
-      $empty_category_error_message = 'Please select a category';
-      $do_redirect = false;
-    } 
+     include "validation_messages.php";
 
       // If all the fields have been filled out, create the post and store it in the db
     if ($do_redirect) {
@@ -62,13 +41,37 @@ switch ($_GET["action"]) {
 
   case 'edit':
 
-    $post_methods = new PostMethods($pdo);
-    $post = $post_methods->list_single_post($_GET["id"]);
+    $title = $_POST["title"];
+    $description = $_POST["description"];
+    $category = $_POST["category"];
+    $image_url = $_POST["image"]; 
+    $post_id = $_GET["id"];
 
-    if(isset($_POST["title"])){
-      $post_methods->edit_post();
-      header('Location: ../views/home_page.php');
+    $post_methods = new PostMethods($pdo);
+
+    include "validation_messages.php";
+
+      // If all the fields have been filled out, create the post and store it in the db
+    if ($do_redirect) {
+
+    // Assign the post you retrieve from the database with its id to a new var called $edited_post
+    $edited_post = $post_methods->list_single_post($_GET["id"]);
+
+    // Set the title, description and category
+    $edited_post->set_title($title);
+    $edited_post->set_description($description);
+    $edited_post->set_category($category);
+
+    // if the image url is not empty, set it
+      if (!empty($image_url)) {
+        $edited_post->set_image($image_url);
+      }
+
+    // Update the post and go back to the single post page
+    $post_methods->edit_post($edited_post);
+    header("Location: ../views/single_post_page.php?id=" . $post_id);
     }
+
 
     break;
 
@@ -77,6 +80,6 @@ if (isset($_POST['remove_post'])) {
     $id = $_GET["id"];
     $this_post = New PostMethods($pdo);
     $this_post->delete_posts($id);
-    header('Location: ../views/home_page.php');
+    header("Location: ../views/home_page.php");
   }
 ?>

--- a/includes/edit_post_form.php
+++ b/includes/edit_post_form.php
@@ -4,7 +4,12 @@ require_once "validation_functions.php";
 
 ?>
 
-<form action="../includes/actions_posts.php?action=edit&id=<?=$post->get_id()?>" method="POST">
+<?php 
+$post_methods = new PostMethods($pdo);
+$post = $post_methods->list_single_post($_GET["id"]);
+?>
+
+<form action="../views/edit_post_page.php?action=edit&id=<?=$post->get_id()?>" method="POST">
 	<div class="form-group">
 		<label for="title">Edit blog title</label> 
 		<input type="text" value="<?=$post->get_title()?>" class="form-control" name="title" placeholder="Title"><div class="<?php get_class_for_error_message($empty_title)?>"><?php echo $empty_title_error_message;?></div>

--- a/includes/validation_messages.php
+++ b/includes/validation_messages.php
@@ -1,0 +1,35 @@
+<?php 
+
+/*
+* This file has the validation error messages we show if the user tries to submit an empty field 
+* Is used both in create_post_form and edit_post form
+*/
+
+// Use $do_redirect to determine if there is a validation error
+$do_redirect = true;
+
+// Title validation: Cannot be empty
+if (empty($title)) {
+  $empty_title = true;
+  $empty_title_error_message = "Title cannot be empty";
+  $do_redirect = false;
+} 
+
+// Description validation: Cannot be empty
+if (empty($description)) {
+  $empty_description = true;
+  $empty_description_error_message = "You cannot submit an empty blog post";
+  $do_redirect = false;
+} 
+
+// Category validation: Cannot be empty
+if (empty($category)) {
+  $empty_category = true;
+  $empty_category_error_message = "Please select a category";
+  $do_redirect = false;
+} 
+
+
+?>
+
+

--- a/views/single_post_page.php
+++ b/views/single_post_page.php
@@ -49,7 +49,7 @@
 				<?php if ($_SESSION["admin"] == 1) :?>
 					<div class="row admin-cta-area justify-content-center">
 						<div class="col=4 edit_button">
-							<form action="../views/edit_post_page.php?action=edit&id=<?=$post->get_id();?>" method="POST">
+							<form action="../views/edit_post_page.php?id=<?=$post->get_id();?>" method="POST">
 								<button type="submit" name="edit_post" class="btn"><i class="fas fa-edit"></i></button>
 			            </form>
 								</div>


### PR DESCRIPTION
Use getter methods instead of POST variables in edit_post method to have consistency.

Assign the post you retrieve from the database with its id to a new variable called $edited_post and set its properties. 

Move the validation messages to a separate file and include them both under case 'create' and case 'edit'. This is to avoid code repetition.

Change header location so it goes to the post you just edited. 

Declare the $post variable on edit_post_form in order to retrieve the data. 

Remove 'action=edit' from the form link in single_post_page because it shouldn't call the action 'edit' before going to the edit_post_page.

Change the form link in edit_post_form so it shows the error messages on edit_post_page.
