### PR TITLE
Remove margin bottom from .container

### DIFF
--- a/sass/pages/_home.scss
+++ b/sass/pages/_home.scss
@@ -76,7 +76,6 @@
   
   .container{
     padding: 0;
-    margin-bottom: 1rem;
   }
   .overlay {
     position: absolute;


### PR DESCRIPTION
Remove margin bottom from class .container in _home.scss because there was a white gap between the body and the bottom of the page on index.php