### PR TITLE
Change font-weight from 500 to 75 on _nav.scss for navbar link hovers

### DIFF
--- a/sass/components/_nav.scss
+++ b/sass/components/_nav.scss
@@ -53,7 +53,7 @@
         margin: 0.2rem 0.2rem 0 0;
       }
       &:hover{
-        font-weight: 500;
+        font-weight: 75;
       }
     }
 


### PR DESCRIPTION
I tried with 'underline' but the effect didn't look good because we already have a lot of lines on the page; so, instead, I made the font-weight lighter.